### PR TITLE
Fixes for USB serial on Linux

### DIFF
--- a/EyeTrackApp/camera.py
+++ b/EyeTrackApp/camera.py
@@ -9,6 +9,7 @@ import platform
 from colorama import Fore
 from config import EyeTrackConfig
 from enum import Enum
+from utils.misc_utils import is_serial
 
 WAIT_TIME = 0.1
 # Serial communication protocol:
@@ -85,7 +86,7 @@ class Camera:
             # than this, otherwise we can deadlock ourselves.
             if self.config.capture_source != None and self.config.capture_source != "":
 
-                if "COM" in str(self.current_capture_source):
+                if is_serial(self.current_capture_source):
                     if (
                         self.serial_connection is None
                         or self.camera_status == CameraState.DISCONNECTED
@@ -125,7 +126,7 @@ class Camera:
             if should_push and not self.capture_event.wait(timeout=0.02):
                 continue
             if self.config.capture_source != None:
-                if "COM" in str(self.current_capture_source):
+                if is_serial(self.current_capture_source):
                     self.get_serial_camera_picture(should_push)
                 else:
                     self.get_cv2_camera_picture(should_push)

--- a/EyeTrackApp/camera.py
+++ b/EyeTrackApp/camera.py
@@ -9,7 +9,7 @@ import platform
 from colorama import Fore
 from config import EyeTrackConfig
 from enum import Enum
-from utils.misc_utils import is_serial
+from utils.misc_utils import is_nt, is_serial
 
 WAIT_TIME = 0.1
 # Serial communication protocol:
@@ -264,8 +264,9 @@ class Camera:
             conn = serial.Serial(
                 baudrate=3000000, port=port, xonxoff=False, dsrdtr=False, rtscts=False
             )
-            # Set explicit buffer size for serial.
-            conn.set_buffer_size(rx_size=32768, tx_size=32768)
+            # Set explicit buffer size for serial. Only available on Windows.
+            if is_nt:
+                conn.set_buffer_size(rx_size=32768, tx_size=32768)
 
             print(
                 f"{Fore.CYAN}[INFO] ETVR Serial Tracker device connected on {port}{Fore.RESET}"

--- a/EyeTrackApp/camera_widget.py
+++ b/EyeTrackApp/camera_widget.py
@@ -10,7 +10,7 @@ from camera import Camera, CameraState
 from osc import EyeId
 import cv2
 import sys
-from utils.misc_utils import PlaySound, SND_FILENAME, SND_ASYNC, resource_path
+from utils.misc_utils import is_serial, PlaySound, SND_FILENAME, SND_ASYNC, resource_path
 import traceback
 import numpy as np
 
@@ -291,7 +291,7 @@ class CameraWidget:
                     self.config.capture_source = None
                 else:
                     if (
-                        len(values[self.gui_camera_addr]) > 5
+                        not is_serial(values[self.gui_camera_addr])
                         and "http" not in values[self.gui_camera_addr]
                         and ".mp4" not in values[self.gui_camera_addr]
                     ):  # If http is not in camera address, add it.

--- a/EyeTrackApp/utils/misc_utils.py
+++ b/EyeTrackApp/utils/misc_utils.py
@@ -13,6 +13,11 @@ if is_nt:
     SND_FILENAME = winsound.SND_FILENAME
     SND_ASYNC = winsound.SND_ASYNC
 
+def is_serial(capture_source):
+    capture_source_str = str(capture_source)
+    serial_prefixes = ["COM", "/dev/tty"]
+    return any(capture_source_str.startswith(prefix) for prefix in serial_prefixes)
+
 def clamp(x, low, high):
     return max(low, min(x, high))
 


### PR DESCRIPTION
# Description

Fixes to make serial run on Linux:
- Allow "/dev/tty" as an alternate prefix to COM for serial source detection
- Don't try to set buffer size outside Windows because the function just doesn't exist.

A couple choices I made that I would like a confirmation on, but seemed reasonable:
- COM is now tested as a prefix, not an "in".
- I changed from checking the UI input for len < 5 to checking for COM prefix. If leaving off the COM is allowed, the length check could be left in, but I couldn't find anywhere that added COM later.
- I test `/dev/tty` as the non-Windows prefix. This is apparently not entirely universal, [e.g. see here](https://github.com/pyserial/pyserial/blob/7aeea35429d15f3eefed10bbb659674638903e3a/serial/tools/list_ports_posix.py), but the exceptions listed are all BSDs. `/dev/` would catch all those, but also `/dev/video*` and so webcam hardware would get caught in that too. (I checked, it can capture e.g. the Index cameras, as long as the `http` prefixing is bypassed for that.) One option if you wanna allow for the cases where auto-detection fails could be to add a toggle or dropdown next to the input box, maybe with a default "auto-detect" that detects most cases. However, I figured I'd improve over the current situation and leave anything further to your discretion.

## Checklist

<!-- - [x] The pull request is done against the latest development branch
- [x] Only relevant files were touched
- [ ] Code change compiles without warnings (which warnings?)
- [x] The code change is tested and works with EyeTrackVR core ESP32 newest release -->

- [x] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
