### PR TITLE
Remove legacy requirements

### DIFF
--- a/EyeTrackApp/requirements.txt
+++ b/EyeTrackApp/requirements.txt
@@ -1,9 +1,0 @@
-python-osc == 1.8.0
-opencv-python == 4.6.0.66
-numpy == 1.23.5
-pye3d == 0.3.1
-pysimplegui == 4.60.4
-pydantic == 1.10.2
-winotify == 1.1.0
-onnxruntime == 1.13.1
-serial == 0.0.97


### PR DESCRIPTION
# Description

A small thing I've noticed, we've switched over to poetry some time ago but legacy requirements.txt stayed as left overs, confusing some folks as what to use to run the app from source. I just cleaned them up 

## Checklist

- [x] The pull request is done against the latest development branch
- [x] Only relevant files were touched
- [x] Code change compiles without warnings
- [x] The code change is tested and works with EyeTrackVR core ESP32 newest release 

- [x] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
