### PR TITLE
Set queue max sizes equal to one another

### DIFF
--- a/EyeTrackApp/camera_widget.py
+++ b/EyeTrackApp/camera_widget.py
@@ -56,10 +56,10 @@ class CameraWidget:
         # Set the event until start is called, otherwise we can block if shutdown is called.
         self.cancellation_event.set()
         self.capture_event = Event()
-        self.capture_queue = Queue(maxsize=1)
-        self.roi_queue = Queue(maxsize=1)
+        self.capture_queue = Queue(maxsize=2)
+        self.roi_queue = Queue(maxsize=2)
 
-        self.image_queue = Queue(maxsize=1)
+        self.image_queue = Queue(maxsize=2)
 
         self.ransac = EyeProcessor(
             self.config,

--- a/EyeTrackApp/eye_processor.py
+++ b/EyeTrackApp/eye_processor.py
@@ -88,8 +88,8 @@ class EyeProcessor:
         baseconfig: "EyetrackConfig",
         cancellation_event: "threading.Event",
         capture_event: "threading.Event",
-        capture_queue_incoming: "queue.Queue",
-        image_queue_outgoing: "queue.Queue",
+        capture_queue_incoming: "queue.Queue(maxsize=2)",
+        image_queue_outgoing: "queue.Queue(maxsize=2)",
         eye_id,
     ):
         self.main_config = EyeTrackSettingsConfig
@@ -466,7 +466,6 @@ class EyeProcessor:
         self.current_algorithm = EyeInfoOrigin.HSRAC
 
     def HSFM(self):
-        print("ee")
         if self.eye_id in [EyeId.LEFT] and self.settings.gui_circular_crop_left:
             self.current_image_gray, self.cct = circle_crop(
                 self.current_image_gray, self.xc, self.yc, self.cc_radius, self.cct


### PR DESCRIPTION
# Description

Set the various queue maxsizes equal to one another.
This seems to make app freezing significantly less frequent then when a mix of 1 and 2 was present. 

Also removes a seemingly unnecessary debug print. 

## Checklist

<!-- - [ ] The pull request is done against the latest development branch
- [ ] Only relevant files were touched
- [ ] Code change compiles without warnings
- [ ] The code change is tested and works with EyeTrackVR core ESP32 newest release -->

- [x] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
