### PR TITLE
Bugfix/v2 params fix

### DIFF
--- a/EyeTrackApp/config.py
+++ b/EyeTrackApp/config.py
@@ -1,7 +1,7 @@
 import json
 import os.path
 import shutil
-from EyeTrackApp.eye import EyeId
+from eye import EyeId
 from pydantic import BaseModel
 from typing import Union, List
 import os

--- a/EyeTrackApp/osc.py
+++ b/EyeTrackApp/osc.py
@@ -1,8 +1,8 @@
 from pythonosc import udp_client
 from pythonosc import osc_server
 from pythonosc import dispatcher
-from EyeTrackApp.config import EyeTrackConfig
-from EyeTrackApp.utils.misc_utils import PlaySound, SND_FILENAME, SND_ASYNC
+from config import EyeTrackConfig
+from utils.misc_utils import PlaySound, SND_FILENAME, SND_ASYNC
 from enum import IntEnum
 import queue
 import threading


### PR DESCRIPTION
# Description

As encountered by Raeschen, changing the imports to import from EyeTrackVR.* without setting up a PYTHONPATH prior, breaks the makefile. 

This change restores the old imports and gets makefile to work again, altho it makes it so `poetry run pytest` fails. 
To get pytest to work again, use `poetry run python -m pytest` 

Additionally, as discovered by Prohurtz, top level \_\_init\_\_.py breaks pyinstaller's runtime imports. I've removed the file to fix the installer. This now breaks the coverage, but seeing as this is only useful for writing tests and seeing what else we haven't tested yet, it's not that important. 

There's a workaround for that, though: https://github.com/pytest-dev/pytest-cov/issues/88

## Checklist

<!-- - [ ] The pull request is done against the latest development branch
- [ ] Only relevant files were touched
- [ ] Code change compiles without warnings
- [ ] The code change is tested and works with EyeTrackVR core ESP32 newest release -->

- [x] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->