### PR TITLE
Feat: Set timer resolution (1ms)

### DIFF
--- a/EyeTrackApp/eyetrackapp.py
+++ b/EyeTrackApp/eyetrackapp.py
@@ -29,7 +29,6 @@ import PySimpleGUI as sg
 import queue
 import requests
 import threading
-from ctypes import windll, c_int
 from camera_widget import CameraWidget
 from config import EyeTrackConfig
 from eye import EyeId
@@ -48,6 +47,7 @@ winmm = None
 
 if is_nt:
     from winotify import Notification
+    from ctypes import windll, c_int
     try:
         winmm = windll.winmm
     except OSError:

--- a/EyeTrackApp/eyetrackapp.py
+++ b/EyeTrackApp/eyetrackapp.py
@@ -44,17 +44,16 @@ import cv2
 import numpy as np
 import uuid
 
+winmm = None
 
 if is_nt:
     from winotify import Notification
+    try:
+        winmm = windll.winmm
+    except OSError:
+        print("\033[91m[WARN] Failed to load winmm.dll\033[0m")
 os.system("color")  # init ANSI color
 
-winmm = None
-try:
-    winmm = windll.winmm
-except OSError:
-    #print("[WARN] Failed to load winmm.dll")
-    pass
 
 # Random environment variable to speed up webcam opening on the MSMF backend.
 # https://github.com/opencv/opencv/issues/17687
@@ -216,7 +215,7 @@ def timerResolution(toggle):
             rc = c_int(winmm.timeBeginPeriod(1))
             if rc.value != 0:
                 # TIMEERR_NOCANDO = 97
-                print(f"[WARN] Failed to set timer resolution: {rc.value}")
+                print(f"\033[93m[WARN] Failed to set timer resolution: {rc.value}\033[0m")
         else:
             winmm.timeEndPeriod(1)
 

--- a/EyeTrackApp/eyetrackapp.py
+++ b/EyeTrackApp/eyetrackapp.py
@@ -29,6 +29,7 @@ import PySimpleGUI as sg
 import queue
 import requests
 import threading
+from ctypes import windll, c_int
 from camera_widget import CameraWidget
 from config import EyeTrackConfig
 from eye import EyeId
@@ -47,6 +48,13 @@ import uuid
 if is_nt:
     from winotify import Notification
 os.system("color")  # init ANSI color
+
+winmm = None
+try:
+    winmm = windll.winmm
+except OSError:
+    #print("[WARN] Failed to load winmm.dll")
+    pass
 
 # Random environment variable to speed up webcam opening on the MSMF backend.
 # https://github.com/opencv/opencv/issues/17687
@@ -202,7 +210,15 @@ def create_window(config, settings, eyes):
         icon=resource_path("Images/logo.ico"),
         background_color="#292929")
 
-
+def timerResolution(toggle):
+    if winmm != None:
+        if toggle:
+            rc = c_int(winmm.timeBeginPeriod(1))
+            if rc.value != 0:
+                # TIMEERR_NOCANDO = 97
+                print(f"[WARN] Failed to set timer resolution: {rc.value}")
+        else:
+            winmm.timeEndPeriod(1)
 
 def main():
     # Get Configuration
@@ -244,6 +260,8 @@ def main():
                     print("[INFO] Toast notifications not supported")
     except:
         print("\033[91m[INFO] Could not check for updates. Please try again later.\033[0m")
+
+    timerResolution(True)
 
     osc_queue: queue.Queue[OSCMessage] = queue.Queue(maxsize=10)
 
@@ -323,6 +341,7 @@ def main():
                     eye.stop()
                 cancellation_event.set()
                 osc_manager.shutdown()
+                timerResolution(False)
                 print("\033[94m[INFO] Exiting EyeTrackApp\033[0m")
                 window.close()
                 os._exit(0)  # I do not like this, but for now this fixes app hang on close


### PR DESCRIPTION
# Description

Reasoning frequent use of "time.time()" which could cause unexpected behaviour. For example "camera.py" used to contain:
&ensp;Line `self.fps = 1 / (self.newft - self.prevft)` which triggered "ZeroDivisionError" if loop ran faster than windows default timer resolution.
&ensp;Your current code correctly handles this example, so this isn't an issue anymore but...

TLDR:
&ensp;Rather than hope that user has a program open that requests a higher timer resolution. Do it ourselves?

## Checklist

<!-- - [ ] The pull request is done against the latest development branch
- [ ] Only relevant files were touched
- [ ] Code change compiles without warnings
- [ ] The code change is tested and works with EyeTrackVR core ESP32 newest release -->

- [x] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
