### PR TITLE
fix: leap calibration samples not saved or having any effect

### DIFF
--- a/EyeTrackApp/settings/modules/BlinkAlgoModule.py
+++ b/EyeTrackApp/settings/modules/BlinkAlgoModule.py
@@ -17,6 +17,7 @@ class BlinkAlgoSettingsValidationModel(BaseValidationModel):
     ibo_fully_close_eye_threshold: Annotated[str, AfterValidator(check_is_float_convertible)]
     gui_circular_crop_left: bool
     gui_circular_crop_right: bool
+    leap_calibration_samples: int
 
 
 class BlinkAlgoSettingsModule(BaseSettingsModule):


### PR DESCRIPTION
# Description

Fix leap calibration samples settings having no effect or could not be modified

## Checklist

<!-- - [ ] The pull request is done against the latest development branch
- [X] Only relevant files were touched
- [X] Code change compiles without warnings
- [X] The code change is tested and works with EyeTrackVR core ESP32 newest release -->

- [X] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
