### PR TITLE
feat: LEAP save calibration

### DIFF
--- a/EyeTrackApp/config.py
+++ b/EyeTrackApp/config.py
@@ -56,6 +56,9 @@ class EyeTrackCameraConfig(BaseModel):
     calib_YOFF: Union[float, None] = None
     calibration_points: List[List[Union[float, None]]] = []
     calibration_points_3d: List[List[Union[float, None]]] = []
+    leap_calibration_percentile_90: float = 0
+    leap_calibration_percentile_2: float = 0
+    leap_calibrated: bool = False
 
 
     def update_capture_source(self, new_camera_address: str):

--- a/EyeTrackApp/eye_processor.py
+++ b/EyeTrackApp/eye_processor.py
@@ -319,7 +319,7 @@ class EyeProcessor:
                 self.rawx,
                 self.rawy,
                 self.eyeopen,
-            ) = self.er_leap.run(self.current_image_gray, self.current_image_gray_clean, self.calibration_frame_counter, self.settings.leap_calibration_samples)
+            ) = self.er_leap.run(self.current_image_gray, self.current_image_gray_clean, self.calibration_frame_counter)
 
         if len(self.prev_y_list) >= 100:  # "lock" eye when close/blink IN TESTING, kinda broke
             self.prev_y_list.pop(0)
@@ -391,7 +391,7 @@ class EyeProcessor:
     def LEAPM(self):
         self.thresh = self.current_image_gray.copy()
         (self.current_image_gray, self.rawx, self.rawy, self.eyeopen,) = self.er_leap.run(
-            self.current_image_gray, self.current_image_gray_clean, self.calibration_frame_counter, self.settings.leap_calibration_samples
+            self.current_image_gray, self.current_image_gray_clean, self.calibration_frame_counter
         )  # TODO: make own self var and LEAP toggle
         self.thresh = self.current_image_gray.copy()
         # todo: lorow, fix this as well
@@ -699,7 +699,7 @@ class EyeProcessor:
 
         if self.settings.gui_LEAP or self.settings.gui_LEAP_lid:
             if self.er_leap is None:
-                self.er_leap = External_Run_LEAP()
+                self.er_leap = External_Run_LEAP(self.config, self.baseconfig)
             algolist[self.settings.gui_LEAP] = self.LEAPM
         else:
             if self.er_leap is not None:


### PR DESCRIPTION
# Description

LEAP doesn't keep its calibration settings between restarts.
I fixed it by adding a parameter in eye settings/config.
I also used this opportunity to optimize leap by not computing the openlist calibration percentiles once calibrated

## Checklist

<!-- - [ ] The pull request is done against the latest development branch
- [X] Only relevant files were touched
- [X] Code change compiles without warnings
- [X] The code change is tested and works with EyeTrackVR core ESP32 newest release -->

- [X] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
