### PR TITLE
fix(OSC): recalibrate not working + refacto

### DIFF
--- a/EyeTrackApp/camera_widget.py
+++ b/EyeTrackApp/camera_widget.py
@@ -348,19 +348,27 @@ class CameraWidget:
             self.stop()
             self.start()
 
-    def recenter_eyes(self, osc_message: OSCMessage):
-        if not isinstance(osc_message.data,bool):
-            return  # just incase we get anything other than bool
+    def recenter_eyes(self):
         self.settings.gui_recenter_eyes = True
 
-    def recalibrate_eyes(self, osc_message: OSCMessage):
-        if not isinstance(osc_message.data,bool):
+    def recalibrate_eyes(self):
+        self.ransac.calibration_frame_counter = self.settings.calibration_samples
+        self.ransac.ibo.clear_filter()
+        PlaySound(resource_path("Audio/start.wav"), SND_FILENAME | SND_ASYNC)
+
+    def osc_recenter_eyes(self, osc_message: OSCMessage):
+        if not isinstance(osc_message.data, bool):
             return  # just incase we get anything other than bool
 
         if osc_message.data:
-            self.ransac.ibo.clear_filter()
-            self.ransac.calibration_frame_counter = self.config.calibration_samples
-            PlaySound("Audio/start.wav", SND_FILENAME | SND_ASYNC)
+            self.recenter_eyes()
+
+    def osc_recalibrate_eyes(self, osc_message: OSCMessage):
+        if not isinstance(osc_message.data, bool):
+            return  # just incase we get anything other than bool
+
+        if osc_message.data:
+            self.recalibrate_eyes()
 
     def render(self, window, event, values):
         changed = False
@@ -455,15 +463,13 @@ class CameraWidget:
                             self.hover_pos = None
 
             if event == self.gui_restart_calibration:
-                self.ransac.calibration_frame_counter = self.settings.calibration_samples
-                self.ransac.ibo.clear_filter()
-                PlaySound(resource_path("Audio/start.wav"), SND_FILENAME | SND_ASYNC)
+                self.recalibrate_eyes()
 
             if event == self.gui_stop_calibration:
                 self.ransac.calibration_frame_counter = 0
 
             if event == self.gui_recenter_eyes:
-                self.settings.gui_recenter_eyes = True
+                self.recenter_eyes()
 
             needs_roi_set = self.config.roi_window_h <= 0 or self.config.roi_window_w <= 0
 

--- a/EyeTrackApp/eyetrackapp.py
+++ b/EyeTrackApp/eyetrackapp.py
@@ -287,15 +287,15 @@ def main():
     osc_manager.register_listeners(
         config.settings.gui_osc_recenter_address,
         [
-            eyes[0].recenter_eyes,
-            eyes[1].recenter_eyes,
+            eyes[0].osc_recenter_eyes,
+            eyes[1].osc_recenter_eyes,
         ],
     )
     osc_manager.register_listeners(
         config.settings.gui_osc_recalibrate_address,
         [
-            eyes[0].recalibrate_eyes,
-            eyes[1].recalibrate_eyes,
+            eyes[0].osc_recalibrate_eyes,
+            eyes[1].osc_recalibrate_eyes,
         ],
     )
 


### PR DESCRIPTION
# Description

Recalibrating trough OSC doesn't work (Causes a crash)
This PR fixes the above-mentioned issue.
I also refactored the code to use the same function for recalibrate/recenter for the gui and osc.

## Checklist

<!-- - [ ] The pull request is done against the latest development branch
- [ ] Only relevant files were touched
- [ ] Code change compiles without warnings
- [ ] The code change is tested and works with EyeTrackVR core ESP32 newest release -->

- [X] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
