### PR TITLE
fix: one euro filter return none

### DIFF
--- a/EyeTrackApp/ellipse_based_pupil_dilation.py
+++ b/EyeTrackApp/ellipse_based_pupil_dilation.py
@@ -126,11 +126,6 @@ class EllipseBasedPupilDilation:
         self.eye_id = eye_id
         self.maxinten = 0
         self.tri_filter = []
-        #  try:
-        #      min_cutoff = float(self.settings.gui_min_cutoff)  # 0.0004
-        #     beta = float(self.settings.gui_speed_coefficient)  # 0.9
-        # except:
-        print("\033[93m[WARN] OneEuroFilter values must be a legal number.\033[0m")
         min_cutoff = 0.00001
         beta = 0.05
         noisy_point = np.array([1, 1])

--- a/EyeTrackApp/intensity_based_openness.py
+++ b/EyeTrackApp/intensity_based_openness.py
@@ -147,11 +147,6 @@ class IntensityBasedOpeness:
         self.eye_id = eye_id
         self.maxinten = 0
         self.tri_filter = []
-        #  try:
-        #      min_cutoff = float(self.settings.gui_min_cutoff)  # 0.0004
-        #     beta = float(self.settings.gui_speed_coefficient)  # 0.9
-        # except:
-        print("\033[93m[WARN] OneEuroFilter values must be a legal number.\033[0m")
         min_cutoff = 0.0004
         beta = 0.9
         noisy_point = np.array([1, 1])

--- a/EyeTrackApp/one_euro_filter.py
+++ b/EyeTrackApp/one_euro_filter.py
@@ -52,5 +52,8 @@ class OneEuroFilter:
                 self.t_prev = t
 
                 return x_hat
+            else:
+                self.x_prev = x
+                return x
         except:
             print("\033[91m[ERROR] One Euro Filter Error. Is your system clock running properly?\033[0m")


### PR DESCRIPTION
# Description

Fix for an issue where when the time diff was equal to 0 and made it impossible to smooth, the function returned None.
This causes LEAP to crash. This was mitigated by sending back the given array as a fallback value 
I also took the opportunity to remove the redundant "OneEuroFilter values must be a legal number." messages

## Checklist

<!-- - [ ] The pull request is done against the latest development branch
- [ ] Only relevant files were touched
- [ ] Code change compiles without warnings
- [ ] The code change is tested and works with EyeTrackVR core ESP32 newest release -->

- [X] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
