### PR TITLE
fix(linux): serial devices with long names would get treated as url

### DIFF
--- a/EyeTrackApp/camera_widget.py
+++ b/EyeTrackApp/camera_widget.py
@@ -381,6 +381,7 @@ class CameraWidget:
                             len(values[self.gui_camera_addr]) > 5
                             and "http" not in values[self.gui_camera_addr]
                             and ".mp4" not in values[self.gui_camera_addr]
+                            and "/dev" not in values[self.gui_camera_addr]
                         ):  # If http is not in camera address, add it.
                             self.config.capture_source = f"http://{values[self.gui_camera_addr]}/"
                         else:


### PR DESCRIPTION
# Description
stop from adding "http://" onto camera addresses that start with "/dev" 

## Checklist

<!-- - [x] The pull request is done against the latest development branch
- [x] Only relevant files were touched
- [x] Code change compiles without warnings
- [x] The code change is tested and works with EyeTrackVR core ESP32 newest release -->

- [x] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
