### PR TITLE
fix: serious performance issue with numpy linalg.inv on linux

### DIFF
--- a/EyeTrackApp/eye_processor.py
+++ b/EyeTrackApp/eye_processor.py
@@ -238,7 +238,7 @@ class EyeProcessor:
                 borderValue=(255, 255, 255),
             )
 
-            inv_matrix = np.linalg.inv(np.vstack((matrix, [0, 0, 1])))[:-1]
+            inv_matrix = cv2.invertAffineTransform(matrix)
             # calculate crop corner locations in original image space
             corners = np.matmul([[0, 0, 1], [roi_w, 0, 1], [0, roi_h, 1], [roi_w, roi_h, 1]], np.transpose(inv_matrix))
             fits_in_bounds = all(0 <= x <= img_w and 0 <= y <= img_h for (x, y) in corners)


### PR DESCRIPTION
# Description

It seems to be related to these two numpy issues: https://github.com/numpy/numpy/issues/27174, https://github.com/numpy/numpy/issues/17166

## Checklist

<!-- - [x] The pull request is done against the latest development branch
- [x] Only relevant files were touched
- [x] Code change compiles without warnings
- [x] The code change is tested and works with EyeTrackVR core ESP32 newest release -->

- [x] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
