### PR TITLE
feat: Add option to synchronize eye Y axis

### DIFF
--- a/EyeTrackApp/config.py
+++ b/EyeTrackApp/config.py
@@ -60,7 +60,6 @@ class EyeTrackCameraConfig(BaseModel):
     leap_calibration_percentile_2: float = 0
     leap_calibrated: bool = False
 
-
     def update_capture_source(self, new_camera_address: str):
         if not new_camera_address:
             self.capture_source = None
@@ -189,6 +188,7 @@ class EyeTrackSettingsConfig(BaseModel):
     gui_left_eye_dominant: bool = False
     gui_outer_side_falloff: bool = False
     gui_eye_dominant_diff_thresh: float = 0.3
+    gui_sync_eye_y: bool = False
 
     gui_legacy_ransac: bool = False
     gui_legacy_ransac_thresh_right: int = 80

--- a/EyeTrackApp/settings/modules/GeneralSettingsModule.py
+++ b/EyeTrackApp/settings/modules/GeneralSettingsModule.py
@@ -12,6 +12,7 @@ class GeneralSettingsValidationModel(BaseValidationModel):
     gui_right_eye_dominant: bool
     gui_left_eye_dominant: bool
     gui_eye_dominant_diff_thresh: float
+    gui_sync_eye_y: bool
 
 
 class GeneralSettingsModule(BaseSettingsModule):
@@ -26,6 +27,7 @@ class GeneralSettingsModule(BaseSettingsModule):
         self.gui_left_eye_dominant = f"-LEFTEYEDOMINANT{widget_id}-"
         self.gui_right_eye_dominant = f"-RIGHTEYEDOMINANT{widget_id}-"
         self.gui_update_check = f"-UPDATECHECK{widget_id}-"
+        self.gui_sync_eye_y = f"-SYNCEYEY{widget_id}-"
 
     # gui_right_eye_dominant: bool = False
     # gui_left_eye_dominant: bool = False
@@ -101,6 +103,15 @@ class GeneralSettingsModule(BaseSettingsModule):
                     key=self.gui_right_eye_dominant,
                     background_color="#424042",
                     tooltip="If one eye is too different than the other, use right eye data",
+                ),
+            ],
+            [
+                sg.Checkbox(
+                    "Sync Eye Y",
+                    default=self.config.gui_sync_eye_y,
+                    key=self.gui_sync_eye_y,
+                    background_color="#424042",
+                    tooltip="Synchronizes the Y axis between both eyes using the average of both eyes if no dominant eye is set, or the dominant eye's Y position if one is set.",
                 ),
             ],
         ]

--- a/EyeTrackApp/utils/eye_falloff.py
+++ b/EyeTrackApp/utils/eye_falloff.py
@@ -4,12 +4,13 @@ from eye import EyeId
 
 
 def velocity_falloff(self, var, out_x, out_y):
-
-    if (
+    use_falloff = (
         self.settings.gui_right_eye_dominant
         or self.settings.gui_left_eye_dominant
         or self.settings.gui_outer_side_falloff
-    ):
+    )
+
+    if use_falloff or self.settings.gui_sync_eye_y:
         # Calculate the distance between the two eyes
         dist = np.sqrt(np.square(var.l_eye_x - var.r_eye_x) + np.square(var.left_y - var.right_y))
         if self.eye_id == EyeId.LEFT:
@@ -21,7 +22,7 @@ def velocity_falloff(self, var, out_x, out_y):
             var.right_y = out_y
 
         # Check if the distance is greater than the threshold
-        if dist > self.settings.gui_eye_dominant_diff_thresh:
+        if use_falloff and dist > self.settings.gui_eye_dominant_diff_thresh:
 
             if self.settings.gui_right_eye_dominant:
                 out_x, out_y = var.r_eye_x, var.right_y
@@ -37,6 +38,14 @@ def velocity_falloff(self, var, out_x, out_y):
                 else:
                     # Mirror the position of the eye with lower velocity to the other eye
                     out_x, out_y = var.l_eye_x, var.left_y
+        elif self.settings.gui_sync_eye_y:
+            # Synchronize the Y position of both eyes
+            if self.settings.gui_right_eye_dominant:
+                out_y = var.right_y
+            elif self.settings.gui_left_eye_dominant:
+                out_y = var.left_y
+            else:
+                out_y = (var.left_y + var.right_y) / 2
         else:
             # If the distance is within the threshold, do not mirror the eyes
             pass

--- a/conftest.py
+++ b/conftest.py
@@ -66,6 +66,7 @@ def eyetrack_settings_config():
         gui_left_eye_dominant=False,
         gui_outer_side_falloff=False,
         gui_eye_dominant_diff_thresh=0.3,
+        gui_sync_eye_y=False,
         gui_legacy_ransac=False,
         gui_legacy_ransac_thresh_right=80,
         gui_legacy_ransac_thresh_left=80,


### PR DESCRIPTION
# Description

This PR adds an option to sync the Y position when using both eye tracking. This allows you to go cross-eyed without looking too silly. The synchronization uses the dominant eye's Y position if selected, otherwise the average of both eyes will be used.

| Setting | Before | After |
| --- | --- | --- |
| <img width="517" height="575" alt="image" src="https://github.com/user-attachments/assets/23afb8c8-b0e7-4f3f-ae81-7cef8c7bff0b" /> | <img width="931" height="629" alt="image" src="https://github.com/user-attachments/assets/473f30a6-1cfd-413e-b9d3-a595cf38b093" /> | <img width="932" height="629" alt="image" src="https://github.com/user-attachments/assets/d8896ee9-fcc0-4d45-a872-81d67e4a1a3a" /> |


## Checklist

<!-- - [x] The pull request is done against the latest development branch
- [x] Only relevant files were touched
- [x] Code change compiles without warnings
- [x] The code change is tested and works with EyeTrackVR core ESP32 newest release -->

- [x] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
