### PR TITLE
fix onnxruntime-gpu in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ matplotlib = "^3.10.7"
 numba = "~0.63.1"
 
 # LINUX: Uses CUDA/ROCm (NVIDIA/AMD)
-onnxruntime-gpu = { version = "*", source = "ort-cuda-13",  platform = 'linux' }
+onnxruntime-gpu = { version = "^1.20.0", source = "ort-cuda-13",  platform = 'linux' }
 # WINDOWS: Uses DirectML (NVIDIA/AMD/Intel)
 onnxruntime-directml = { version = "^1.20.0", platform = 'win32' }
 # MACOS: Uses CoreML/MPS (Neural Engine & Metal)


### PR DESCRIPTION
# Description
On linux, attempting to install dependencies via poetry results in:
```
  - Downgrading onnxruntime-gpu (1.21.0.dev20250306002 -> 1.19.2): Failed

    | Unable to find installation candidates for onnxruntime-gpu (1.19.2)
    | 
    | This is likely not a Poetry issue.
    | 
    |   - 10 candidate(s) were identified for the package
    |   - 10 wheel(s) were skipped as your project's environment does not support the identified abi tags
    | 
    | Solutions:
    | Make sure the lockfile is up-to-date. You can try one of the following;
    | 
    |     1. Regenerate lockfile: poetry lock --no-cache --regenerate
    |     2. Update package     : poetry update --no-cache onnxruntime-gpu
    | 
    | If neither works, please first check to verify that the onnxruntime-gpu has published wheels available from your configured source (ort-cuda-13) that are compatible with your environment- ie. operating system, architecture (x86_64, arm64 etc.), python interpreter.
    | 
    | You can also run your poetry command with -v to see more information.

```

I changed the version format to match the other onnx components and now it installs dependencies successfully.

## Checklist

- [x] The pull request is done against the latest development branch
- [x] Only relevant files were touched
- [x] Code change compiles without warnings
- [x] The code change is tested and works with EyeTrackVR core ESP32 newest release

- [x] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
