### PR TITLE
fix: remove accidental-mkdir-in-logger

### DIFF
--- a/EyeTrackApp/utils/logging_utils.py
+++ b/EyeTrackApp/utils/logging_utils.py
@@ -94,8 +94,7 @@ def setup_logging(app_name: str = "EyeTrackApp") -> Path:
     except Exception:
         pass
 
-    log_dir = _app_root() / LOG_DIR_NAME
-    log_dir.mkdir(parents=True, exist_ok=True)
+    log_dir = log_directory()
     log_path = log_dir / f"{LOG_NAME_PREFIX}-{datetime.now():%Y%m%d-%H%M%S}.log"
 
     root_logger = logging.getLogger()


### PR DESCRIPTION
# Description

When running ETVR on read-only filesystems, `setup_logging` still tries to create a log directory. The correct way is to use the existing `log_directory()` function that handles read-only installation directories properly.

## Checklist

<!-- - [ ] The pull request is done against the latest development branch
- [ ] Only relevant files were touched
- [ ] Code change compiles without warnings
- [ ] The code change is tested and works with EyeTrackVR core ESP32 newest release -->

- [x] I accept the [CLA](https://github.com/RedHawk989/EyeTrackVR/blob/main/repo-tools/CONTRIBUTING.md#contributor-license-agreement-cla).

<!-- _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_ -->
